### PR TITLE
Cdsk 1163 jwt token integration - 

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -850,8 +850,8 @@ export class Client extends EventEmitter {
     this.accessTokenExpiryInEpoch = timeInEpoch;
     
     setTimeout(() => {
+      this.emit('onLogout', 'ACCESS_TOKEN_EXPIRED');
       if(this.callUUID == null) {
-        this.emit('onLogout', 'ACCESS_TOKEN_EXPIRED');
         this._logout();
       }
       else {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -771,10 +771,10 @@ export class Client extends EventEmitter {
 
   private getUsernameFromToken = (parsedToken: string | any): string => {
     if (parsedToken['sub']) {
-      return parsedToken['sub'];
+      return `${parsedToken['sub']}_${parsedToken['iss']}`;
     }
     const randomTenDigitNumber = new Date().valueOf();
-    return "puser" + randomTenDigitNumber.toString() + "jt";
+    return `${randomTenDigitNumber.toString()}_${parsedToken['iss']}`;
   };
 
   private getNbfFromToken = (parsedToken: string | any): any => {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -848,17 +848,6 @@ export class Client extends EventEmitter {
 
   setExpiryTimeInEpoch = (timeInEpoch: number): void => {
     this.accessTokenExpiryInEpoch = timeInEpoch;
-    
-    setTimeout(() => {
-      this.emit('onLogout', 'ACCESS_TOKEN_EXPIRED');
-      if(this.callUUID == null) {
-        this._logout();
-      }
-      else {
-        this.accessToken = null;
-      }
-    }, Number(this.accessTokenExpiryInEpoch) * 1000);
-
   };
   getTokenExpiryTimeInEpoch = (): number | null => {
     return this.accessTokenExpiryInEpoch;

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -774,7 +774,7 @@ export class Client extends EventEmitter {
       return `${parsedToken['sub']}_${parsedToken['iss']}`;
     }
     const randomTenDigitNumber = new Date().valueOf();
-    return `${randomTenDigitNumber.toString()}_${parsedToken['iss']}`;
+    return `puser${randomTenDigitNumber.toString()}jt_${parsedToken['iss']}`;
   };
 
   private getNbfFromToken = (parsedToken: string | any): any => {

--- a/lib/managers/account.ts
+++ b/lib/managers/account.ts
@@ -418,7 +418,7 @@ class Account {
     Plivo.log.debug('Login failed : ', error.cause);
     this.cs.userName = null;
     this.cs.password = null;
-    this.cs.emit('onLoginFailed', error.cause);
+    this.cs.emit('onLoginFailed', 'INVALID_ACCESS_TOKEN');
   };
 
   /**

--- a/lib/managers/account.ts
+++ b/lib/managers/account.ts
@@ -399,6 +399,8 @@ class Account {
     }
     this.cs.userName = null;
     this.cs.password = null;
+    this.cs.accessToken = null;
+
     if (this.cs.isLogoutCalled === true) {
       this.cs.isLogoutCalled = false;
       this.cs.emit('onLogout');
@@ -406,6 +408,10 @@ class Account {
         clearInterval(this.cs.networkChangeInterval);
       }
       this.message = null;
+    }
+
+    if(this.cs.callUUID == null) {
+      this.cs.logout();
     }
   };
 

--- a/lib/managers/account.ts
+++ b/lib/managers/account.ts
@@ -401,6 +401,8 @@ class Account {
     this.cs.password = null;
     this.cs.accessToken = null;
 
+    this.cs.emit('onLogout', 'ACCESS_TOKEN_EXPIRED');
+
     if (this.cs.isLogoutCalled === true) {
       this.cs.isLogoutCalled = false;
       this.cs.emit('onLogout');

--- a/lib/managers/incomingCall.ts
+++ b/lib/managers/incomingCall.ts
@@ -239,6 +239,13 @@ const onEnded = (incomingCall: CallSession) => (evt: SessionEndedEvent): void =>
   Plivo.log.debug(`Incoming call ended - ${incomingCall.callUUID}`);
   Plivo.log.info('Incoming call ended');
   incomingCall.onEnded(cs, evt);
+
+  //  logout if logged in by token and token get expired
+  if(cs.isAccessToken && cs.accessToken == null) {
+    cs.emit('onLogout', 'ACCESS_TOKEN_EXPIRED');
+    cs.logout();
+  }
+
   // reset back pingpong to idle state timeouts
   resetPingPong({
     client: cs,

--- a/lib/managers/outgoingCall.ts
+++ b/lib/managers/outgoingCall.ts
@@ -345,6 +345,13 @@ const onEnded = (evt: SessionEndedEvent): void => {
     Plivo.log.debug(`Outgoing call ended - ${cs._currentSession.callUUID}`);
     Plivo.log.info('Outgoing call ended');
     cs._currentSession.onEnded(cs, evt);
+
+    //  logout if logged in by token and token get expired
+    if(cs.isAccessToken && cs.accessToken == null) {
+      cs.emit('onLogout', 'ACCESS_TOKEN_EXPIRED');
+      cs.logout();
+    }
+
     // reset back pingpong to idle state timeouts
     resetPingPong({
       client: cs,


### PR DESCRIPTION
- update issuer param. (from "Iss" to "iss")
- display token expiry msg after token expire - CSDK-1299
- auto logout after call hangup if token get expired 
- display "INVALID_ACCESS_TOKEN" message for invalid token - CSDK-1281
- fix issue CSDK-1267 | Not able to login with "normal Plivo login" credentials after trying to login using expired token.
- apply sub_authid format for plivo logged user