### PR TITLE
Vpt 5397

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable GA release changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v2.2.21 (unreleased)
+
+**Bug Fixes**
+- Fixed: Enhanced device ID constraints to use exact matching for more reliable device selection.
+- Fixed: Added null-safe operator for device label matching to prevent potential errors.
+
 ## v2.2.20 (released@ 25-08-2025)
 
 **Bug Fixes**

--- a/lib/media/audioDevice.ts
+++ b/lib/media/audioDevice.ts
@@ -395,13 +395,13 @@ const updateAudioContraints = function (state, deviceId, label) {
           }
         });
       });
-      (Plivo.audioConstraints as MediaTrackConstraints).deviceId = deviceId;
+      (Plivo.audioConstraints as MediaTrackConstraints).deviceId = { exact: deviceId };
       delete (Plivo.audioConstraints as any).optional;
       updateGroupIdDeviceIdMap(availableAudioDevices);
     } else if (typeof Plivo.audioConstraints === 'boolean') {
-      Plivo.audioConstraints = { deviceId };
+      Plivo.audioConstraints = { deviceId: { exact: deviceId } };
     } else {
-      (Plivo.audioConstraints as MediaTrackConstraints).deviceId = deviceId;
+      (Plivo.audioConstraints as MediaTrackConstraints).deviceId = { exact: deviceId };
     }
     return {
       audio: Plivo.audioConstraints,
@@ -521,7 +521,7 @@ export const matchDevices = function (
   activeOutputDevice,
 ): boolean {
   const checkDeviceLabelName = (inputDeviceLabel, outputDeviceLable) => {
-    const match = inputDeviceLabel.match(/\(([^)]+)\)/);
+    const match = inputDeviceLabel?.match(/\(([^)]+)\)/);
     return match && outputDeviceLable.includes(match[1]);
   };
 
@@ -843,7 +843,19 @@ export const inputDevices = ((): InputDevices => ({
       return '';
     }
     if (Plivo.audioConstraints && Plivo.audioConstraints.deviceId) {
-      return Plivo.audioConstraints.deviceId;
+      if (
+        typeof Plivo.audioConstraints.deviceId === "object" &&
+        Plivo.audioConstraints.deviceId !== null &&
+        "exact" in Plivo.audioConstraints.deviceId
+      ) {
+        if ("exact" in Plivo.audioConstraints.deviceId) {
+          return Plivo.audioConstraints.deviceId.exact;
+        } else if ("ideal" in Plivo.audioConstraints.deviceId) {
+          return Plivo.audioConstraints.deviceId.ideal;
+        }
+      } else {
+        return Plivo.audioConstraints.deviceId;
+      }
     }
     return '';
   },

--- a/lib/media/audioDevice.ts
+++ b/lib/media/audioDevice.ts
@@ -845,13 +845,17 @@ export const inputDevices = ((): InputDevices => ({
     if (Plivo.audioConstraints && Plivo.audioConstraints.deviceId) {
       if (
         typeof Plivo.audioConstraints.deviceId === "object" &&
-        Plivo.audioConstraints.deviceId !== null &&
-        "exact" in Plivo.audioConstraints.deviceId
+        Plivo.audioConstraints.deviceId !== null
       ) {
         if ("exact" in Plivo.audioConstraints.deviceId) {
           return Plivo.audioConstraints.deviceId.exact;
         } else if ("ideal" in Plivo.audioConstraints.deviceId) {
           return Plivo.audioConstraints.deviceId.ideal;
+        } else {
+          Plivo.log.error(
+            "Invalid audio constraints",
+            Plivo.audioConstraints.deviceId
+          );
         }
       } else {
         return Plivo.audioConstraints.deviceId;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plivo-browser-sdk",
   "title": "plivo-browser-sdk",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "description": "This library allows you to connect with plivo's voice enviroment from browser",
   "main": "./dist/plivobrowsersdk.js",
   "types": "index.d.ts",


### PR DESCRIPTION
In some devices, when the user changes the microphone from browserSDK, the stream was not sending audio through the new `deviceId`.
This can happen in some cases & OS as previously we were using:
```javascript
deviceId: <deviceId>
```

But now we are using:
```javascript
deviceId: {exact: <deviceId>}
```

Here are the [docs](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring)